### PR TITLE
issue#17を解消

### DIFF
--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,4 +1,4 @@
-jQuery("#comment-<%= @comment.id %>").remove();
+$("#comment-<%= @comment.id %>").remove();
 $(".show-comments-<%= @comment.id %> a").css('display', 'inline');
-$(".show-comments-<%= @comment.id %> .comment-content").html('<%= @comment.content %>');
+$(".show-comments-<%= @comment.id %> .comment-content").html('<%= j(simple_format(@comment.content)) %>');
 $(".show-comments-<%= @comment.id %> .comment-content").css('display','inline');

--- a/app/views/items/_comment.html.erb
+++ b/app/views/items/_comment.html.erb
@@ -11,7 +11,9 @@
     </div>
   </div>
     <span>
-      <div class="comment-content"><%= comment.content %></div>
+      <div class="comment-content">
+        <%= simple_format(comment.content) %>
+      </div>
       <% if @current_user.id == comment.user_id %>
         <div class="post-menus">
           <%= link_to("編集", "/comments/#{comment.id}", remote: true) %>


### PR DESCRIPTION
原因：
⇒javascript内でコメントをhtmlにする際、改行をエスケープできていなかったため。

対応：
⇒エスケープを行うj(escape_javascript)メソッドを挿入して解消。