### PR TITLE
circleci時にのみ、必要なセキュリティグループルールを追加するよう修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
-      - run: echo ${AWS_PAGER=} >> $BASH_ENV # AWS CLI
   
       # AWS CLIインストール
       - run:  
@@ -38,8 +37,6 @@ jobs:
             aws --version
             aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32 
             
-      
-      
       # master.keyの生成
       - run: sudo echo ${MASTER_KEY} > ~/sample/config/master.key
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,18 @@ jobs:
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
       
+      # aws CLIインストール
+      - run:  
+          name: Install aws CLI   
+          command: |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install
+            aws --version
+            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32"
+            
+      
+      
       # master.keyの生成
       - run: sudo echo ${MASTER_KEY} > ~/sample/config/master.key
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,14 @@ jobs:
       
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
-  
+      
+      # circleci環境のパブリックIPを取得
+      - run: 
+          name: Get public IP
+          command: | 
+            IP=`curl -f -s ifconfig.me` 
+            echo "export IP=${IP}" >> $BASH_ENV
+
       # AWS CLIインストール
       - run:  
           name: Install aws CLI   
@@ -35,13 +42,9 @@ jobs:
             unzip awscliv2.zip
             sudo ./aws/install
             aws --version
-            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32 
             
       # master.keyの生成
       - run: sudo echo ${MASTER_KEY} > ~/sample/config/master.key
-      
-      # デバッグ用
-      # - run: sudo cat ~/sample/config/master.key
       
       # bundlerのバージョン1.17.3へのアップデート
       - run:  
@@ -92,14 +95,12 @@ jobs:
           fingerprints:
             - "03:0e:cc:fb:6d:e0:d0:6f:31:5c:8b:e4:bd:8e:aa:b7"
 
-      - run: pwd
-      - run: cat Capfile
-      - run: cat ~/.ssh/id_rsa_030eccfb6de0d06f315c8be4bd8eaab7
-      - run: cat config/deploy.rb
-      - run: cat config/deploy/production.rb
-      - run: cat ~/.bashrc  
-      - run: echo $PRIVATE_ADDRESS_PRODUCTION
+      # デプロイ用の一時ルールをセキュリティグループに追加
+      - run: aws ec2 authorize-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32 
       
+      # セキュリティグループ反映までスリープ
+      - run: sleep 5
+
       # 本番環境へのデプロイ
       #- deploy:
       #    name: Capistrano deploy
@@ -109,4 +110,7 @@ jobs:
             #fi
       - run: bundle exec cap production deploy    
      
-      
+      # デプロイ用の一時ルールをセキュリティグループから削除
+      - run:
+          command: aws ec2 revoke-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32
+          when: always # デプロイ結果に関係なくセキュリティグループを戻すため

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
       
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
-      - run: echo export AWS_PAGER="" >> $BASH_ENV
+      - run: echo ${AWS_PAGER=} >> $BASH_ENV # AWS CLI
   
-      # aws CLIインストール
+      # AWS CLIインストール
       - run:  
           name: Install aws CLI   
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             unzip awscliv2.zip
             sudo ./aws/install
             aws --version
-            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32"
+            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32
             
       
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
       
+      - run: echo ${AWS_ACCESS_KEY_ID}
       # aws CLIインストール
       - run:  
           name: Install aws CLI   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,12 +95,6 @@ jobs:
           fingerprints:
             - "03:0e:cc:fb:6d:e0:d0:6f:31:5c:8b:e4:bd:8e:aa:b7"
 
-      # デプロイ用の一時ルールをセキュリティグループに追加
-      #- run: aws ec2 authorize-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32 
-      
-      # セキュリティグループ反映までスリープ
-      #- run: sleep 5
-
       # 本番環境へのデプロイ
       - run:
           name: Capistrano deploy
@@ -125,6 +119,7 @@ jobs:
      
       # デプロイ用の一時ルールをセキュリティグループから削除
       - run:
+          name: Delete a temporary rule from security group 
           command: |
             if [ -f /tmp/authorize.sg ]; then
               aws ec2 revoke-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
       
       # 環境変数の展開
       - run: echo ${CUSTOM_ENV} | base64 --decode >> $BASH_ENV
-      
-      - run: echo ${AWS_ACCESS_KEY_ID}
+      - run: echo export AWS_PAGER="" >> $BASH_ENV
+  
       # aws CLIインストール
       - run:  
           name: Install aws CLI   
@@ -36,7 +36,7 @@ jobs:
             unzip awscliv2.zip
             sudo ./aws/install
             aws --version
-            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32
+            aws ec2 authorize-security-group-ingress --group-id sg-0452cdef694632ab2 --protocol tcp --port 22 --cidr 172.17.230.1/32 
             
       
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,21 +96,37 @@ jobs:
             - "03:0e:cc:fb:6d:e0:d0:6f:31:5c:8b:e4:bd:8e:aa:b7"
 
       # デプロイ用の一時ルールをセキュリティグループに追加
-      - run: aws ec2 authorize-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32 
+      #- run: aws ec2 authorize-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32 
       
       # セキュリティグループ反映までスリープ
-      - run: sleep 5
+      #- run: sleep 5
 
       # 本番環境へのデプロイ
-      #- deploy:
-      #    name: Capistrano deploy
-      #    command: |
-            #if [ "${CIRCLE_BRANCH}" != "master" ]; then
-            #  exit 0
-            #fi
-      - run: bundle exec cap production deploy    
+      - run:
+          name: Capistrano deploy
+          command: |
+            # masterブランチ以外ではデプロイしない
+            if [ "${CIRCLE_BRANCH}" != "master" ]; then
+              exit 0
+            fi
+            
+            # masterブランチの場合
+            # デプロイ用の一時ルールをセキュリティグループに追加
+            aws ec2 authorize-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32
+            
+            # セキュリティグループの変更を記録
+            echo true > /tmp/authorize.sg 
+            
+            # ルール変更反映まで待機する
+            sleep 5
+            
+            # capistranoによるデプロイ実行
+            bundle exec cap production deploy    
      
       # デプロイ用の一時ルールをセキュリティグループから削除
       - run:
-          command: aws ec2 revoke-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32
+          command: |
+            if [ -f /tmp/authorize.sg ]; then
+              aws ec2 revoke-security-group-ingress --group-id ${AWS_SECURITY_GROUP_ID} --protocol tcp --port 22 --cidr ${IP}/32
+            fi
           when: always # デプロイ結果に関係なくセキュリティグループを戻すため


### PR DESCRIPTION
sshを0.0.0.0で許可していたが、セキュリティ上の懸念があるため、
circleci上の変動するパブリックipを都度取得し、動的にセキュリティグループにルールを追加するよう修正。